### PR TITLE
Fix Vercel routing: prevent bundle.js from being redirected to index.…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,14 @@
   ],
   "routes": [
     {
+      "src": "/bundle.js",
+      "dest": "/bundle.js"
+    },
+    {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }


### PR DESCRIPTION
…html

- Add explicit routes for /bundle.js and /assets/* in vercel.json
- Prevents the catch-all route from intercepting static file requests
- Fixes 'Uncaught SyntaxError: Unexpected token '<'' error caused by HTML being served instead of JS
- Ensures proper serving of JavaScript bundle and game assets