### PR TITLE
Fix runtime errors: add missing createComponents method and fix textu…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ class Main {
             .add(AtlasKeys.ATLAS_XML)
             .add(AtlasKeys.FONT_FNT)
             .add(AtlasKeys.BG_HUD_IMAGE)
-            .add(AtlasKeys.BG_IMAGE)
+            .add("bg_image", AtlasKeys.BG_IMAGE)
             .add(AtlasKeys.BG_POPUP_IMAGE)
             // Load new game piece images
             .add("piece_normal_1", AtlasKeys.GAME_PIECES_PATH + "piece_normal_1.png")

--- a/src/matchthree/utils/AtlasKeys.ts
+++ b/src/matchthree/utils/AtlasKeys.ts
@@ -57,7 +57,16 @@ export class AtlasKeys {
         if (PIXI.loader.resources[atlasKey]) {
             return PIXI.loader.resources[atlasKey].texture;
         }
+        // Check if it's a direct path resource
+        if (PIXI.loader.resources && PIXI.loader.resources[atlasKey]) {
+            return PIXI.loader.resources[atlasKey].texture;
+        }
         // Fallback to atlas texture cache
-        return this.textureCache[atlasKey];
+        if (this.textureCache && this.textureCache[atlasKey]) {
+            return this.textureCache[atlasKey];
+        }
+        // If texture not found, log error and return a fallback
+        console.warn(`Texture not found: ${atlasKey}`);
+        return Texture.WHITE;
     }
 }

--- a/src/matchthree/utils/PixiFactory.ts
+++ b/src/matchthree/utils/PixiFactory.ts
@@ -44,7 +44,7 @@ export class PixiFactory {
         return new Sprite(texture);
     }
     public static getBackground(): Sprite {
-        const background = new Sprite(AtlasKeys.getTexture(AtlasKeys.BG_IMAGE));
+        const background = new Sprite(AtlasKeys.getTexture("bg_image"));
         // Scale the background to fit the game viewport
         background.width = ViewPortSize.MAX_WIDTH;
         background.height = ViewPortSize.MAX_HEIGHT;

--- a/src/matchthree/views/HomeView.ts
+++ b/src/matchthree/views/HomeView.ts
@@ -19,6 +19,10 @@ export class HomeView extends Container {
     constructor() {
         super();
 
+        this.createComponents();
+    }
+
+    public createComponents(): void {
         this.createBackground();
         this.createImages();
         this.createButtons();


### PR DESCRIPTION
…re loading

- Add createComponents() method to HomeView to match mediator expectations
- Fix background image loading by adding proper resource name 'bg_image' in PIXI loader
- Improve texture loading error handling with fallback to Texture.WHITE
- Fixes 'this.view.createComponents is not a function' error
- Fixes 'Cannot read properties of undefined' texture loading error