### PR TITLE
Add createComponents method to all main views to prevent runtime errors

### DIFF
--- a/src/matchthree/views/IntroView.ts
+++ b/src/matchthree/views/IntroView.ts
@@ -9,6 +9,10 @@ export class IntroView extends Container {
     constructor() {
         super();
 
+        this.createComponents();
+    }
+
+    public createComponents(): void {
         this.setupBackground();
         this.setupImages();
         this.setupText();

--- a/src/matchthree/views/LevelSelectView.ts
+++ b/src/matchthree/views/LevelSelectView.ts
@@ -17,6 +17,10 @@ export class LevelSelectView extends Container {
     constructor() {
         super();
 
+        this.createComponents();
+    }
+
+    public createComponents(): void {
         this.createBackground();
         this.createText();
         this.createButton();

--- a/src/matchthree/views/OptionsView.ts
+++ b/src/matchthree/views/OptionsView.ts
@@ -20,6 +20,10 @@ export class OptionsView extends Container {
     constructor() {
         super();
 
+        this.createComponents();
+    }
+
+    public createComponents(): void {
         this.createBackgrounds();
         this.createTexts();
         this.createButtons();


### PR DESCRIPTION
- Add createComponents() method to IntroView, LevelSelectView, and OptionsView
- Ensures all views have consistent interface expected by mediators
- Prevents 'createComponents is not a function' errors during view initialization
- Refactored constructors to call createComponents() for better consistency