### PR TITLE
Add error handling for button creation and event listener binding

### DIFF
--- a/src/matchthree/mediators/HomeViewMediator.ts
+++ b/src/matchthree/mediators/HomeViewMediator.ts
@@ -9,8 +9,12 @@ export class HomeViewMediator extends Mediator<HomeView> {
     @inject(FlowService) private flowService: FlowService;
 
     public initialize(): void {
-        this.eventMap.mapListener(this.view.playButton, "click", this.playButton_onClick, this);
-        this.eventMap.mapListener(this.view.optionsButton, "click", this.optionsButton_onClick, this);
+        if (this.view.playButton) {
+            this.eventMap.mapListener(this.view.playButton, "click", this.playButton_onClick, this);
+        }
+        if (this.view.optionsButton) {
+            this.eventMap.mapListener(this.view.optionsButton, "click", this.optionsButton_onClick, this);
+        }
     }
     public destroy(): void {
         this.eventMap.unmapListeners();

--- a/src/matchthree/views/HomeView.ts
+++ b/src/matchthree/views/HomeView.ts
@@ -52,14 +52,22 @@ export class HomeView extends Container {
         // const logoImage: Sprite = PixiFactory.getImage(AtlasKeys.LOGO_MATCH_THREE);
     }
     private createButtons(): void {
-        this._playButton = PixiFactory.getIconButton(AtlasKeys.ICON_RESUME, IconButton.TYPE_MEDIUM);
-        this._playButton.x = ViewPortSize.HALF_WIDTH;
-        this._playButton.y = ViewPortSize.MAX_HEIGHT - 50 - MagicValues.BORDER_OFFSET_BOTTOM;
-        this.addChild(this._playButton);
+        try {
+            this._playButton = PixiFactory.getIconButton(AtlasKeys.ICON_RESUME, IconButton.TYPE_MEDIUM);
+            if (this._playButton) {
+                this._playButton.x = ViewPortSize.HALF_WIDTH;
+                this._playButton.y = ViewPortSize.MAX_HEIGHT - 50 - MagicValues.BORDER_OFFSET_BOTTOM;
+                this.addChild(this._playButton);
+            }
 
-        this._optionsButton = PixiFactory.getIconButton(AtlasKeys.ICON_CONFIG, IconButton.TYPE_MEDIUM);
-        this._optionsButton.x = ViewPortSize.HALF_WIDTH;
-        this._optionsButton.y = ViewPortSize.MAX_HEIGHT - MagicValues.BORDER_OFFSET_BOTTOM;
-        this.addChild(this._optionsButton);
+            this._optionsButton = PixiFactory.getIconButton(AtlasKeys.ICON_CONFIG, IconButton.TYPE_MEDIUM);
+            if (this._optionsButton) {
+                this._optionsButton.x = ViewPortSize.HALF_WIDTH;
+                this._optionsButton.y = ViewPortSize.MAX_HEIGHT - MagicValues.BORDER_OFFSET_BOTTOM;
+                this.addChild(this._optionsButton);
+            }
+        } catch (error) {
+            console.error("Error creating buttons:", error);
+        }
     }
 }

--- a/src/matchthree/views/components/IconButton.ts
+++ b/src/matchthree/views/components/IconButton.ts
@@ -17,7 +17,8 @@ export class IconButton extends Sprite {
     private _ico: Sprite;
 
     constructor(shapeType: String = IconButton.TYPE_SMALL) {
-        super(AtlasKeys.getTexture(shapeType + "_up.png"));
+        const upTexture = AtlasKeys.getTexture(shapeType + "_up.png");
+        super(upTexture);
 
         const downStateTexture: Texture = AtlasKeys.getTexture(shapeType + "_down.png");
         const upStateTexture: Texture = AtlasKeys.getTexture(shapeType + "_up.png");
@@ -34,9 +35,14 @@ export class IconButton extends Sprite {
             this.removeChild(this._ico);
         }
 
-        this._ico = new Sprite(AtlasKeys.getTexture(name));
-        this._ico.anchor.set(0.5);
-        this.addChild(this._ico);
+        const iconTexture = AtlasKeys.getTexture(name);
+        if (iconTexture) {
+            this._ico = new Sprite(iconTexture);
+            this._ico.anchor.set(0.5);
+            this.addChild(this._ico);
+        } else {
+            console.warn(`Icon texture not found: ${name}`);
+        }
     }
     private setInitialValues(): void {
         this.anchor.set(0.5);


### PR DESCRIPTION
- Add null checks in HomeViewMediator before binding event listeners
- Add try-catch error handling in HomeView button creation
- Add null checks in IconButton setIco method to prevent texture loading errors
- Prevents 'Cannot read properties of undefined (reading addEventListener)' errors
- Improves robustness of UI component initialization