### PR TITLE
Fix DOM loading issue causing addEventListener error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,15 @@ class Main {
         canvas.style.left = '50%';
         canvas.style.top = '50%';
         canvas.style.transform = 'translate(-50%, -50%)';
-        document.body.appendChild(canvas);
+        
+        // Ensure DOM is ready before appending canvas
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => {
+                document.body.appendChild(canvas);
+            });
+        } else {
+            document.body.appendChild(canvas);
+        }
     }
     public onLoad(): void {
         AtlasKeys.update(PIXI.utils.TextureCache);
@@ -75,5 +83,14 @@ class Main {
         window.requestAnimationFrame(this.render);
     };
 }
-const main = new Main();
-main.render();
+
+// Ensure DOM is ready before initializing the game
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        const main = new Main();
+        main.render();
+    });
+} else {
+    const main = new Main();
+    main.render();
+}


### PR DESCRIPTION
- Add DOM readiness checks before canvas manipulation
- Ensure game initialization waits for DOMContentLoaded
- Fixes: bundle.js:26 Uncaught TypeError: Cannot read properties of undefined (reading 'addEventListener')
- Resolves Vercel deployment console errors