### PR TITLE
Fix LevelSelectButton creation and null handling

### DIFF
--- a/src/matchthree/mediators/LevelSelectViewMediator.ts
+++ b/src/matchthree/mediators/LevelSelectViewMediator.ts
@@ -36,13 +36,15 @@ export class LevelSelectViewMediator extends Mediator<LevelSelectView> {
         for (let i = 0; i < levels.length; i++) {
             levelInfo = levels[i];
             levelButton = this.view.createLevelButton(String(levelInfo.levelId + 1));
-            levelButton.x =
-                ViewPortSize.HALF_WIDTH - (levelButton.width + 4) + Math.floor(i % 3) * (levelButton.width + 4);
-            levelButton.y = 180 + Math.floor(i / 3) * (levelButton.height + 8);
-            levelButton.setStars(ScoreUtils.getNumStars(levelInfo.hiScore, levelInfo.scoreStarts));
-            levelButton.anchor.set(0.5);
-            this.levelsIds.set(levelButton, levels[i].levelId);
-            this.eventMap.mapListener(levelButton, "click", this.levelButton_onTriggeredHandler, this);
+            if (levelButton) {
+                levelButton.x =
+                    ViewPortSize.HALF_WIDTH - (levelButton.width + 4) + Math.floor(i % 3) * (levelButton.width + 4);
+                levelButton.y = 180 + Math.floor(i / 3) * (levelButton.height + 8);
+                levelButton.setStars(ScoreUtils.getNumStars(levelInfo.hiScore, levelInfo.scoreStarts));
+                levelButton.anchor.set(0.5);
+                this.levelsIds.set(levelButton, levels[i].levelId);
+                this.eventMap.mapListener(levelButton, "click", this.levelButton_onTriggeredHandler, this);
+            }
         }
     }
     private backButton_onTriggeredHandler(e: any): void {

--- a/src/matchthree/utils/PixiFactory.ts
+++ b/src/matchthree/utils/PixiFactory.ts
@@ -84,6 +84,12 @@ export class PixiFactory {
         return bg;
     }
     public static getLevelSelectButton(): LevelSelectButton {
-        return new LevelSelectButton();
+        try {
+            const button = new LevelSelectButton();
+            return button;
+        } catch (error) {
+            console.error("Failed to create LevelSelectButton", error);
+            return null;
+        }
     }
 }

--- a/src/matchthree/views/LevelSelectView.ts
+++ b/src/matchthree/views/LevelSelectView.ts
@@ -27,10 +27,13 @@ export class LevelSelectView extends Container {
     }
     public createLevelButton(text: string): LevelSelectButton {
         const level: LevelSelectButton = PixiFactory.getLevelSelectButton();
-        level.setText(text);
-        this.addChild(level);
-
-        return level;
+        if (level) {
+            level.setText(text);
+            this.addChild(level);
+            return level;
+        }
+        console.warn("Failed to create level button");
+        return null;
     }
     private createBackground(): void {
         this.addChild(PixiFactory.getBackground());

--- a/src/matchthree/views/components/LevelSelectButton.ts
+++ b/src/matchthree/views/components/LevelSelectButton.ts
@@ -4,7 +4,7 @@ import { IconButton } from "./IconButton";
 
 export class LevelSelectButton extends IconButton {
     constructor() {
-        super();
+        super(IconButton.TYPE_SMALL);
     }
 
     public setText(text: string): void {


### PR DESCRIPTION
- Fix LevelSelectButton constructor to properly call super with button type
- Add null checks in LevelSelectView.createLevelButton method
- Add null checks in LevelSelectViewMediator.createMapButtons method
- Improve error handling in PixiFactory.getLevelSelectButton method
- Prevents 'createLevelButton is not a function' errors